### PR TITLE
Ugly Password Script

### DIFF
--- a/sample_bin/ugly_password.pl
+++ b/sample_bin/ugly_password.pl
@@ -20,7 +20,7 @@ open my $fh, '<:raw', '/dev/random';
 read $fh, my $bytes, 32;
 close $fh;
 
-#Convert each byte to a printable ascii char (ascii 33 - 126).
+# Convert each byte to a printable ascii char (ascii 33 - 126).
 my $output = "";
 foreach my $i (0..(length $bytes) - 1) {
 	$output .=  chr((unpack 'C', substr $bytes, $i, 1) % 94 + 33);

--- a/sample_bin/ugly_password.pl
+++ b/sample_bin/ugly_password.pl
@@ -1,15 +1,15 @@
-#!/usr/bin/env perl -l
+#!/usr/bin/env perl
 
 # File: ugly_password.pl
-# Date: August 6, 2018
+# Date: August 7, 2018
 # Author: Peter Bailie
 #
 # This will output to STDOUT a randomly generated ugly password using the
 # printable ASCII character range of 33 - 126.  Passwords are based on
 # /dev/random to ensure reliable pseudo-random entropy.
 #
-# /dev/random is blocking, so there may be a delay in output when the seed pool
-# needs to be refreshed.
+# /dev/random is blocking, so there may be a (possibly lengthy) delay in
+# output when the seed pool needs to be refreshed.
 
 use strict;
 use warnings;
@@ -18,15 +18,9 @@ use autodie;
 my $PW_LENGTH = 32;  # length of the ugly password in characters.
 my ($fh, $byte, $val, $output);
 
-$output = "";  # password output
 open $fh, '<:raw', '/dev/random';
-build_ugly_password();
-close $fh;
-print STDOUT $output;
-exit 0;
-
-# Recursive subroutine to generate a random char and build the ugly password.
-sub build_ugly_password {
+$output = "";  # password output
+while (length $output < $PW_LENGTH) {
 	# Read a random byte and scale it to range 33 - 126.
 	read $fh, $byte, 1;
 	$val = (unpack 'C', $byte) % 94 + 33;
@@ -37,9 +31,6 @@ sub build_ugly_password {
 		# Character qualifies, append it to password.
 		$output .= chr $val;
 	}
-
-	# Go again, if needed.
-	if (length $output < $PW_LENGTH) {
-		build_ugly_password();
-	}
 }
+close $fh;
+print STDOUT $output . "\n";

--- a/sample_bin/ugly_password.pl
+++ b/sample_bin/ugly_password.pl
@@ -27,11 +27,12 @@ exit 0;
 
 # Recursive subroutine to generate a random char and build the ugly password.
 sub build_ugly_password {
+	# Read a random byte and scale it to range 33 - 126.
 	read $fh, $byte, 1;
 	$val = (unpack 'C', $byte) % 94 + 33;
 
 	# Single quote, double quote, and backtick chars are disqualified.
-	# Prevents edge cases for copy/pasting ugly passwords to cli.
+	# Prevents some edge cases for copy/pasting ugly passwords to psql or cli.
 	if ($val != 34 && $val != 39 && $val != 96) {
 		# Character qualifies, append it to password.
 		$output .= chr $val;

--- a/sample_bin/ugly_password.pl
+++ b/sample_bin/ugly_password.pl
@@ -1,0 +1,29 @@
+#!/usr/bin/env perl -l
+
+# File: ugly_password.pl
+# Date: August 6, 2018
+# Author: Peter Bailie
+#
+# This will output to STDOUT a randomly generated 32 character ugly password
+# using the printable ASCII character range of 33 - 126.  Passwords are based
+# on /dev/random to ensure reliable pseudo-random entropy.
+#
+# /dev/random is blocking, so there may be a delay in output when the seed pool
+# needs to be refreshed.
+
+use strict;
+use warnings;
+use autodie;
+
+# Get 32 random bytes from /dev/random
+open my $fh, '<:raw', '/dev/random';
+read $fh, my $bytes, 32;
+close $fh;
+
+#Convert each byte to a printable ascii char (ascii 33 - 126).
+my $output = "";
+foreach my $i (0..(length $bytes) - 1) {
+	$output .=  chr((unpack 'C', substr $bytes, $i, 1) % 94 + 33);
+}
+
+print STDOUT $output;


### PR DESCRIPTION
Generates a randomly generated long ugly password.  Uses /dev/random to ensure reliable entropy.  Could be used to password protect Submitty system accounts.