### PR TITLE
Create m-to-n_cpp.sh

### DIFF
--- a/sample_bin/m-to-n_cpp.sh
+++ b/sample_bin/m-to-n_cpp.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Students enrolled in data structures will also be enrolled in csci1199 for
+# the "u19" term.  Later on, CS1 enrollment can also be enrolled into csci1199
+# for the "f19" term.
+
+# Those already enrolled in csci1199 will have their registration_section and
+# manual_registration data points updated from data structures/CS1.
+
+# Root required
+if [[ $UID -ne 0 ]]; then
+    echo "Root is required."
+    exit 1
+fi
+
+# Process data structures enrollment to C++
+# (that is, f19/csci1200 to u19/csci1199)
+su postgres -c "psql submitty -c \"
+INSERT INTO courses_users
+    (SELECT 'u19', 'csci1199', user_id, user_group, registration_section, manual_registration FROM courses_users WHERE semester='f19' AND course='csci1200' AND user_group=4)
+ON CONFLICT (semester, course, user_id)
+    DO UPDATE SET registration_section=EXCLUDED.registration_section, manual_registration=EXCLUDED.manual_registration\""
+
+# Uncomment all five lines, below, to allow processing CS1 enrollment to C++
+# (that is, f19/csci1100 to f19/csci1199)
+
+# su postgres -c "psql submitty -c \"
+# INSERT INTO courses_users
+#    (SELECT 'f19', 'csci1199', user_id, user_group, registration_section, manual_registration FROM courses_users WHERE semester='f19' AND course='csci1100' AND user_group=4)
+# ON CONFLICT (semester, course, user_id)
+#     DO UPDATE SET registration_section=EXCLUDED.registration_section, manual_registration=EXCLUDED.manual_registration\""


### PR DESCRIPTION
Many to many student enrollment from CS1/data structures to C++ bootstrap course.  f19/data_structures students are enrolled in u19/csci1199.  f19/CS1 students are enrolled in f19/csci1199.  Note that csci1199 for CS1 is commented out, so to be inactive for now.

This will only enroll students (user_group=4) into csci1199.  And students already enrolled will have their `registration_section` and `manual_registration` updated.  This also permits students who drop (null registration section) in data structures or CS1 to also be automatically dropped in csci1199.

Script should be run on Submitty production as root via cron.