### PR TITLE
Student auto feed script update

### DIFF
--- a/student_auto_feed/config.php
+++ b/student_auto_feed/config.php
@@ -68,61 +68,9 @@ define('VALIDATE_NUM_FIELDS', 10);
 // The following constants are used to read the CSV auto feed file provided by
 // the registrar / data warehouse.  ***THESE NEED TO BE SET.
 //
-// CSV_AUTH can be set to 'local' or 'remote_password' or 'remote_keypair'.
-//
-//          'local' means the CSV file can be read locally by the script, so no
-//          remote authentication details are needed.
-//
-//          'remote_password' means that the file must be accessed on another
-//           server, and authentication is by password.
-//           q.v. CSV_AUTH_PASSWORD
-//
-//           'remote_key' means that the file must be accessed on another
-//           server, and authentication is by RSA key pair.
-//           q.v. CSV_AUTH_PUBKEY, CSV_AUTH_PRIVKEY, CSV_PRIVKEY_PASSPHRASE
-//
 // CSV_FILE is the full path of the student auto feed file, regardless if it is
 //          accessed locally or remotely.
-//
-// CSV_REMOTE_SERVER is the fully qualified domain name of the server that hosts
-//                   the student feed CSV file.  This constant is ignored when
-//                   CSV_AUTH is set to 'local'.
-//
-// CSV_AUTH_USER is the user account to access the student feed CSV, when the
-//               file exists on a remote server.  This constant is ignored when
-//               CSV_AUTH is set to 'local'.
-//
-// CSV_AUTH_PASSWORD is the user account password required to access the student
-//                   feed CSV on a remote server.  This constant is ignored when
-//                   CSV_AUTH is set to anything other than 'remote_password'.
-//
-// CSV_AUTH_PUBKEY is the path to the public key used to authenticate with the
-//                 remote server that has the student feed CSV.  The public key
-//                 needs to be in OpenSSH format.  This constant is ignored
-//                 when CSV_AUTH is set to anything other than 'remote_keypair'.
-//
-// CSV_AUTH_PRIVKEY is the path to the private key used to communicate with the
-//                  remote server that has the student feed CSV.  This constant
-//                  is ignored when CSV_AUTH is set to anything other than
-//                  'remote_keypair'.
-//
-// CSV_PRIVKEY_PASSPHRASE is the passphrase used to encrypt the private key.
-//                        Set to null, if the private key is not encrypted.
-//                        This constant is ignored when CSV_AUTH is set to
-//                        anything other than 'remote_keypair'.
-//                        NOTE: To use encrypted keys with an Ubuntu SSH/SFTP
-//                              host, libssh2 needs be manually recompiled with
-//                              OpenSSH.  Otherwise, authentication will always
-//                              fail. q.v. https://bugs.php.net/bug.php?id=58573
-//                              and http://php.net/manual/en/function.ssh2-auth-pubkey-file.php
-define('CSV_AUTH',               'remote_keypair');
 define('CSV_FILE',               '/path/to/datafile.csv');
-define('CSV_REMOTE_SERVER',      'fileserver.myuniversity.edu');
-define('CSV_AUTH_USER',          'remote_user');
-define('CSV_AUTH_PASSWORD',      null);
-define('CSV_AUTH_PUBKEY',        '/path/to/rsa_key.pub');
-define('CSV_AUTH_PRIVKEY',       '/path/to/rsa_key.pfx');
-define('CSV_PRIVKEY_PASSPHRASE', 'MySecretPassphrase');
 
 //Define what character is delimiting each field.  ***THIS NEEDS TO BE SET.
 //EXAMPLE: chr(9) is the tab character.

--- a/student_auto_feed/config.php
+++ b/student_auto_feed/config.php
@@ -5,7 +5,7 @@
  * config.php script used by submitty_student_auto_feed
  * By Peter Bailie, Systems Programmer (RPI dept of computer science)
  *
- * Requires minimum PHP version 5.6 with pgsql, iconv, and ssh2 extensions.
+ * Requires minimum PHP version 7.0 with pgsql and iconv extensions.
  *
  * Configuration of submitty_student_auto_feed is structured through defined
  * constants.  Expanded instructions can be found at
@@ -49,10 +49,7 @@ define('ERROR_LOG_FILE', '/var/local/submitty/bin/auto_feed_error.log');
 //           add all pertinant student-is-registered codes that can be found in
 //           your CSV data dump.  EXAMPLE: 'RA' may mean "registered by advisor"
 //           and 'RW' may mean "registered via web"
-define('STUDENT_REGISTERED_CODES', serialize( array(
-'RA',
-'RW',
-)));
+define('STUDENT_REGISTERED_CODES', array('RA', 'RW'));
 
 //An exceptionally small file size can indicate a problem with the feed, and
 //therefore the feed should not be processed to preserve data integrity of the
@@ -70,7 +67,7 @@ define('VALIDATE_NUM_FIELDS', 10);
 //
 // CSV_FILE is the full path of the student auto feed file, regardless if it is
 //          accessed locally or remotely.
-define('CSV_FILE',               '/path/to/datafile.csv');
+define('CSV_FILE', '/path/to/datafile.csv');
 
 //Define what character is delimiting each field.  ***THIS NEEDS TO BE SET.
 //EXAMPLE: chr(9) is the tab character.
@@ -108,9 +105,5 @@ define('CONVERT_CP1252', true);
 
 //Allows "\r" EOL encoding.  This is rare but exists (e.g. Excel for Macintosh).
 ini_set('auto_detect_line_endings', true);
-
-//Needed to access student feed on a remote server.
-//You can comment this out if the student feed is accessed locally.
-ini_set("allow_url_fopen", true);
 
 ?>

--- a/student_auto_feed/submitty_student_auto_feed.php
+++ b/student_auto_feed/submitty_student_auto_feed.php
@@ -235,7 +235,7 @@ class submitty_student_auto_feed {
             /* -----------------------------------------------------------------
              * $row successfully validated.  Include it.
              * NOTE: Most cases, $row is associated EITHER as a registered
-             *       course or as a mapped course but it is possible $row is
+             *       course or as a mapped course, but it is possible $row is
              *       associated as BOTH a registered course and a mapped course.
              * -------------------------------------------------------------- */
 
@@ -425,7 +425,7 @@ SQL;
     }
 
     /**
-     * Load auto feed data.
+     * Open auto feed CSV data file.
      *
      * @access private
      * @return boolean  indicates success/failure of opening and locking CSV file.
@@ -741,18 +741,17 @@ SQL;
             case pg_query(self::$db, $sql['courses_users']['update']):
                 $this->log_it(strtoupper($course_name) . " (UPDATE) : " . pg_last_error(self::$db));
                 pg_query(self::$db, $sql['rollback']);
-                continue;
+                break;
             case pg_query(self::$db, $sql['courses_users']['insert']):
                 $this->log_it(strtoupper($course_name) . " (INSERT) : " . pg_last_error(self::$db));
                 pg_query(self::$db, $sql['rollback']);
-                continue;
+                break;
              case pg_query_params(self::$db, $sql['courses_users']['dropped_students'], array($course_name, self::$semester)):
                 $this->log_it(strtoupper($course_name) . " (DROPPED STUDENTS) : " . pg_last_error(self::$db));
                 pg_query(self::$db, $sql['rollback']);
-                continue;
+                break;
             default:
                 pg_query(self::$db, $sql['commit']);
-                continue;
             }
         }
 
@@ -780,14 +779,14 @@ class cli_args {
     /** @var array holds all CLI argument flags and their values */
     private static $args            = array();
     /** @var string usage help message */
-    private static $help_usage      = "Usage: submitty_student_auto_feed.php [-h | --help] (-t [term code])" . PHP_EOL;
+    private static $help_usage      = "Usage: submitty_student_auto_feed.php [-h | --help] (-t term code)" . PHP_EOL;
     /** @var string short description help message */
     private static $help_short_desc = "Read student enrollment CSV and upsert to Submitty database." . PHP_EOL;
     /** @var string argument list help message */
     private static $help_args_list  = <<<HELP
-Arguments
--h --help       Show this help message.
--t [term code]  Term code associated with student enrollment.
+Arguments:
+-h, --help    Show this help message.
+-t term code  Term code associated with current student enrollment.  Required.
 
 HELP;
 

--- a/student_auto_feed/submitty_student_auto_feed.php
+++ b/student_auto_feed/submitty_student_auto_feed.php
@@ -68,7 +68,7 @@ class submitty_student_auto_feed {
         $db_host     = DB_HOST;
         $db_user     = DB_LOGIN;
         $db_password = DB_PASSWORD;
-        self::$db = pg_connect("host={$db_host} dbname=submitty user={$db_user} password={$db_password} sslmode=prefer");
+        self::$db = pg_connect("host={$db_host} dbname=submitty user={$db_user} password={$db_password} sslmode=require");
 
         //Make sure there's a DB connection to Submitty.
         if (pg_connection_status(self::$db) !== PGSQL_CONNECTION_OK) {


### PR DESCRIPTION
Updates the following:
- No longer sends an entire course to the NULL section when that course is not represented in the data feed (manual flag no longer required).
- Mapped courses is no longer mutually exclusive with registered courses.  This will allow a course's enrollment to be duplicated to another course.  (i.e. csci1100 -> csci1199)
- Some code cleanup/updates involving CSV processing.
- SSL required in DB connection (was "preferred").
- Removed code that is not used.
   - Removed remote CSV access.  SSH2 bindings has proved to be very problematic (I can get a C assertion from libssh2!), but I will not support any form of network access to the student data file without encryption due to FERPA concerns.  Meanwhile, we do not access the CSV over the network at RPI leaving little point in supporting this feature.
   - -g CLI argument removed.  Legacy feature to auto-determine term code hasn't been used in a years, and I do not expect to ever use it again.