### PR TITLE
[Refactor:API] Semester to Term in Database Calls

### DIFF
--- a/nightly_db_backup/db_backup.py
+++ b/nightly_db_backup/db_backup.py
@@ -131,7 +131,7 @@ def main():
 
 	# GET ACTIVE COURSES FROM 'MASTER' DB
 	try:
-		sql = "select course from courses where semester='{}'".format(semester)
+		sql = "select course from courses where term='{}'".format(semester)
 		# psql postgresql://user:password@host/dbname?sslmode=prefer -c "COPY (SQL code) TO STDOUT"
 		process = "psql postgresql://{}:{}@{}/submitty?sslmode=prefer -c \"COPY ({}) TO STDOUT\"".format(DB_USER, DB_PASS, DB_HOST, sql)
 		result = list(subprocess.check_output(process, shell=True).decode('utf-8').split(os.linesep))[:-1]

--- a/pam_accounts/accounts.php
+++ b/pam_accounts/accounts.php
@@ -132,7 +132,7 @@ class make_accounts {
 			self::$db_query = <<<SQL
 SELECT DISTINCT user_id
 FROM courses_users
-WHERE semester=$1
+WHERE term=$1
 SQL;
 			self::$workflow_function = 'add_user';
             break;
@@ -141,7 +141,7 @@ SQL;
         	self::$db_query = <<<SQL
 SELECT DISTINCT cu.user_id
 FROM courses_users as cu
-LEFT OUTER JOIN courses as c ON cu.course=c.course AND cu.semester=c.semester
+LEFT OUTER JOIN courses as c ON cu.course=c.course AND cu.term=c.term
 WHERE cu.user_group=1 OR (cu.user_group<>1 AND c.status=1)
 SQL;
 			self::$workflow_function = 'add_user';
@@ -163,7 +163,7 @@ SQL;
 			self::$db_query = <<<SQL
 SELECT DISTINCT cu.user_id
 FROM courses_users as cu
-LEFT OUTER JOIN courses as c ON cu.course=c.course AND cu.semester=c.semester
+LEFT OUTER JOIN courses as c ON cu.course=c.course AND cu.term=c.term
 WHERE cu.user_group<>1 AND c.status<>1
 SQL;
 			self::$workflow_function = 'remove_user';

--- a/sample_bin/registration_section_resync.php
+++ b/sample_bin/registration_section_resync.php
@@ -84,7 +84,7 @@ class registration_section_resync {
 		//Loop through academic terms
 		foreach (self::$academic_terms as $term) {
 			//Get courses list for $term
-			$res = pg_query_params(self::$db_conn['master'], "SELECT course FROM courses WHERE semester = $1", array($term));
+			$res = pg_query_params(self::$db_conn['master'], "SELECT course FROM courses WHERE term = $1", array($term));
 			if ($res === false) {
 				exit(sprintf("Error reading course list for %s.%s", $term, PHP_EOL));
 			}
@@ -107,7 +107,7 @@ class registration_section_resync {
 				}
 
 				//First retrieve registration sections in master DB
-				$res = pg_query_params(self::$db_conn['master'], "SELECT registration_section_id FROM courses_registration_sections WHERE semester=$1 AND course=$2", array($term, $course));
+				$res = pg_query_params(self::$db_conn['master'], "SELECT registration_section_id FROM courses_registration_sections WHERE term=$1 AND course=$2", array($term, $course));
 				if ($res === false) {
 					fprintf(STDERR, "Error reading registration sections from master DB: %s %s.%sSkipping %s %s.%s", $term, $course, PHP_EOL, $term, $course, PHP_EOL);
 					$this->close_db_conn('course');
@@ -135,7 +135,7 @@ class registration_section_resync {
 
 				//INSERT $sync_list to master DB, ON CONFLICT DO NOTHING (prevents potential PK violations).  We're using DB schema trigger to complete resync.
 				foreach($sync_list as $section) {
-					$res = pg_query_params(self::$db_conn['master'], "INSERT INTO courses_registration_sections (semester, course, registration_section_id) VALUES ($1, $2, $3) ON CONFLICT ON CONSTRAINT courses_registration_sections_pkey DO UPDATE SET semester=$1, course=$2, registration_section_id=$3", array($term, $course, $section));
+					$res = pg_query_params(self::$db_conn['master'], "INSERT INTO courses_registration_sections (term, course, registration_section_id) VALUES ($1, $2, $3) ON CONFLICT ON CONSTRAINT courses_registration_sections_pkey DO UPDATE SET term=$1, course=$2, registration_section_id=$3", array($term, $course, $section));
 					if ($res === false) {
 						fprintf(STDERR, "Error during re-sync procedure: %s %s section %s.%s.This section could not be synced.%s", $term, $course, $section, PHP_EOL, PHP_EOL);
 						$this->close_db_conn('course');

--- a/student_auto_feed/add_drop_report.php
+++ b/student_auto_feed/add_drop_report.php
@@ -147,7 +147,7 @@ class db {
         }
 
         // Undergraduate courses from DB.
-        $sql = "SELECT course FROM courses WHERE semester=$1 AND status=1";
+        $sql = "SELECT course FROM courses WHERE term=$1 AND status=1";
         $params = array($term);
         $res = pg_query_params(self::$db, $sql, $params);
         if ($res === false)
@@ -170,7 +170,7 @@ class db {
         }
 
         // mapped courses from DB
-        $sql = "SELECT course, mapped_course FROM mapped_courses WHERE semester=$1";
+        $sql = "SELECT course, mapped_course FROM mapped_courses WHERE term=$1";
         $params = array($term);
         $res = pg_query_params(self::$db, $sql, $params);
         if ($res === false) {
@@ -206,7 +206,7 @@ class db {
             $grad_course = array_search($course, $mapped_courses);
             if ($grad_course === false) {
                 // COURSE HAS NO GRAD SECTION (not mapped).
-                $sql = "SELECT COUNT(*) FROM courses_users WHERE semester=$1 AND course=$2 AND user_group=4 AND registration_section IS NOT NULL";
+                $sql = "SELECT COUNT(*) FROM courses_users WHERE term=$1 AND course=$2 AND user_group=4 AND registration_section IS NOT NULL";
                 $params = array($term, $course);
                 $res = pg_query_params(self::$db, $sql, $params);
                 if ($res === false)
@@ -214,14 +214,14 @@ class db {
                 $course_enrollments[$course] = (int) pg_fetch_result($res, 0);
 
                 // Get manual flag count
-                $sql = "SELECT COUNT(*) FROM courses_users WHERE semester=$1 AND course=$2 AND user_group=4 AND registration_section IS NOT NULL AND manual_registration=TRUE";
+                $sql = "SELECT COUNT(*) FROM courses_users WHERE term=$1 AND course=$2 AND user_group=4 AND registration_section IS NOT NULL AND manual_registration=TRUE";
                 $res = pg_query_params(self::$db, $sql, $params);
                 if ($res === false)
                     die("Failed to lookup counts with manual flag set for {$course}\n");
                 $manual_flags[$course] = (int) pg_fetch_result($res, 0);
             } else {
                 // UNDERGRADUATE SECTION
-                $sql = "SELECT COUNT(*) FROM courses_users WHERE semester=$1 AND course=$2 AND user_group=4 AND registration_section='1'";
+                $sql = "SELECT COUNT(*) FROM courses_users WHERE term=$1 AND course=$2 AND user_group=4 AND registration_section='1'";
                 $params = array($term, $course);
                 $res = pg_query_params(self::$db, $sql, $params);
                 if ($res === false)
@@ -229,21 +229,21 @@ class db {
                 $course_enrollments[$course] = (int) pg_fetch_result($res, 0);
 
                 // Get manual flag count
-                $sql = "SELECT COUNT(*) FROM courses_users WHERE semester=$1 AND course=$2 AND user_group=4 AND registration_section='1' AND manual_registration=TRUE";
+                $sql = "SELECT COUNT(*) FROM courses_users WHERE term=$1 AND course=$2 AND user_group=4 AND registration_section='1' AND manual_registration=TRUE";
                 $res = pg_query_params(self::$db, $sql, $params);
                 if ($res === false)
                     die("Failed to lookup counts with manual flag set for {$course} (undergrads)\n");
                 $manual_flags[$course] = (int) pg_fetch_result($res, 0);
 
                 // GRADUATE SECTION
-                $sql = "SELECT COUNT(*) FROM courses_users WHERE semester=$1 AND course=$2 AND user_group=4 AND registration_section='2'";
+                $sql = "SELECT COUNT(*) FROM courses_users WHERE term=$1 AND course=$2 AND user_group=4 AND registration_section='2'";
                 $res = pg_query_params(self::$db, $sql, $params);
                 if ($res === false)
                     die("Failed to lookup enrollments for {$grad_course}\n");
                 $course_enrollments[$grad_course] = (int) pg_fetch_result($res, 0);
 
                 // Get manual flag count
-                $sql = "SELECT COUNT(*) FROM courses_users WHERE semester=$1 AND course=$2 AND user_group=4 AND registration_section='2' AND manual_registration=TRUE";
+                $sql = "SELECT COUNT(*) FROM courses_users WHERE term=$1 AND course=$2 AND user_group=4 AND registration_section='2' AND manual_registration=TRUE";
                 $res = pg_query_params(self::$db, $sql, $params);
                 if ($res === false)
                     die("Failed to lookup counts with manual flag set for {$course} (grads)\n");

--- a/student_auto_feed/ssaf_sql.php
+++ b/student_auto_feed/ssaf_sql.php
@@ -21,19 +21,19 @@ class sql {
     public const GET_COURSES = <<<SQL
 SELECT course
 FROM courses
-WHERE semester=$1
+WHERE term=$1
 AND status=1
 SQL;
 
     public const GET_MAPPED_COURSES = <<<SQL
 SELECT course, registration_section, mapped_course, mapped_section
 FROM mapped_courses
-WHERE semester=$1
+WHERE term=$1
 SQL;
 
     public const GET_COURSE_ENROLLMENT_COUNT = <<<SQL
 SELECT count(*) AS num_students FROM courses_users
-WHERE semester=$1
+WHERE term=$1
 AND course=$2
 AND user_group=4
 AND registration_section IS NOT NULL
@@ -72,7 +72,7 @@ SQL;
     // UPSERT courses_users table
     public const UPSERT_COURSES_USERS = <<<SQL
 INSERT INTO courses_users (
-    semester,
+    term,
     course,
     user_id,
     user_group,
@@ -80,7 +80,7 @@ INSERT INTO courses_users (
     registration_type,
     manual_registration
 ) VALUES ($1, $2, $3, $4, $5, $6, $7)
-ON CONFLICT (semester, course, user_id) DO UPDATE
+ON CONFLICT (term, course, user_id) DO UPDATE
 SET registration_section=
         CASE WHEN courses_users.user_group=4
             AND courses_users.manual_registration=FALSE
@@ -98,7 +98,7 @@ SQL;
     // INSERT courses_registration_sections table
     public const INSERT_REG_SECTION = <<<SQL
 INSERT INTO courses_registration_sections (
-    semester,
+    term,
     course,
     registration_section_id,
     course_section_id
@@ -135,12 +135,12 @@ FROM (
     LEFT OUTER JOIN tmp_enrolled
     ON courses_users.user_id=tmp_enrolled.user_id
     WHERE tmp_enrolled.user_id IS NULL
-    AND courses_users.semester=$1
+    AND courses_users.term=$1
     AND courses_users.course=$2
     AND courses_users.user_group=4
 ) AS dropped
 WHERE courses_users.user_id=dropped.user_id
-AND courses_users.semester=$1
+AND courses_users.term=$1
 AND courses_users.course=$2
 AND courses_users.user_group=4
 AND courses_users.manual_registration=FALSE


### PR DESCRIPTION
To match [PR #9630](https://github.com/Submitty/Submitty/pull/9630), the word `term` is changed to `semester` in database accesses.