### PR TITLE
[Feature:System] Don't set given names to empty string

### DIFF
--- a/student_auto_feed/ssaf_sql.php
+++ b/student_auto_feed/ssaf_sql.php
@@ -47,9 +47,9 @@ class sql {
         user_numeric_id,
         user_givenname,
         user_familyname,
-        NULLIF(user_preferred_givenname, ''),
+        user_preferred_givenname,
         user_email
-    ) VALUES ($1, $2, $3, $4, $5, $6)
+    ) VALUES ($1, $2, $3, $4, NULLIF($5,''), $6)
     ON CONFLICT (user_id) DO UPDATE
     SET user_numeric_id=EXCLUDED.user_numeric_id,
         user_givenname=EXCLUDED.user_givenname,

--- a/student_auto_feed/ssaf_sql.php
+++ b/student_auto_feed/ssaf_sql.php
@@ -47,7 +47,7 @@ class sql {
         user_numeric_id,
         user_givenname,
         user_familyname,
-        user_preferred_givenname,
+        NULLIF(user_preferred_givenname, ''),
         user_email
     ) VALUES ($1, $2, $3, $4, $5, $6)
     ON CONFLICT (user_id) DO UPDATE

--- a/student_auto_feed/ssaf_sql.php
+++ b/student_auto_feed/ssaf_sql.php
@@ -57,7 +57,7 @@ class sql {
         user_preferred_givenname=
             CASE WHEN users.user_updated=FALSE
                 AND users.instructor_updated=FALSE
-                AND COALESCE(users.user_preferred_givenname, '')=''
+                AND users.user_preferred_givenname IS NULL
             THEN EXCLUDED.user_preferred_givenname
             ELSE users.user_preferred_givenname
             END,

--- a/student_auto_feed/ssaf_sql.php
+++ b/student_auto_feed/ssaf_sql.php
@@ -58,7 +58,7 @@ class sql {
             CASE WHEN users.user_updated=FALSE
                 AND users.instructor_updated=FALSE
                 AND COALESCE(users.user_preferred_givenname, '')=''
-            THEN EXCLUDED.user_preferred_givenname
+            THEN NULLIF(EXCLUDED.user_preferred_givenname, '')
             ELSE users.user_preferred_givenname
             END,
         user_email=

--- a/student_auto_feed/ssaf_sql.php
+++ b/student_auto_feed/ssaf_sql.php
@@ -58,7 +58,7 @@ class sql {
             CASE WHEN users.user_updated=FALSE
                 AND users.instructor_updated=FALSE
                 AND COALESCE(users.user_preferred_givenname, '')=''
-            THEN NULLIF(EXCLUDED.user_preferred_givenname, '')
+            THEN EXCLUDED.user_preferred_givenname
             ELSE users.user_preferred_givenname
             END,
         user_email=


### PR DESCRIPTION
Currently this script is setting all users preferred names to an empty string upon running, which causes many database queries to become substantially longer to account for both values indicating no desired preferred name.